### PR TITLE
[GCAT-009]Retrofit request is blank when minify is enable

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}


### PR DESCRIPTION
* Fixing proguard-rules.pro with prevent obfuscation with the serializedName fields when the minify is enable

step: 9